### PR TITLE
Error on warnings raised in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,11 @@ include = ["bg_space*"]
 
 [tool.setuptools_scm]
 
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error",
+]
+
 [tool.black]
 target-version = ['py38', 'py39', 'py310', 'py311']
 skip-string-normalization = false

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,5 @@
 import itertools
+from contextlib import nullcontext
 
 import numpy as np
 import pytest
@@ -328,7 +329,20 @@ def test_stack_map_offset(s_dict, t_dict, f_in, result):
     s = AnatomicalSpace(**s_dict)
     t = AnatomicalSpace(**t_dict)
 
-    assert np.allclose(t.map_stack_to(s, np.ones((2, 2, 2)), **f_in), result)
+    if np.any(np.array(t_dict["offset"]) < 0):
+        ctx = pytest.warns(
+            UserWarning,
+            match=(
+                "Stack is out of target shape on at least one axis, "
+                "mapped stack will be empty"
+            ),
+        )
+    else:
+        ctx = nullcontext()
+
+    with ctx:
+        mapped = t.map_stack_to(s, np.ones((2, 2, 2)), **f_in)
+    assert np.allclose(mapped, result)
 
 
 def test_points_mapping():


### PR DESCRIPTION
This PR catches any warnings that are emitted by tests, and errors on them. This is generally good practice, to make sure the code isn't emitting any warnings, or if it is that they are intended.

There was one warning I had to catch, which seemed sensible to me. Whoever reviews this should double check this warning is expected.
