### PR TITLE
Fix branches that CI is run on

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -2,9 +2,8 @@ name: Run tests
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ main ]
   pull_request:
-    branches: [ "master" ]
 
 jobs:
   lint:


### PR DESCRIPTION
Since the 'main' branch got renamed, this updates the CI configuration so that tests run on all pull requests, and the main branch.