### PR TITLE
Retire old name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
+# `bg-space` has become `brainglobe-space`
+
+To continue receiving updates, please switch to using [`brainglobe-space`](https://github.com/brainglobe/brainglobe-space) instead of this package.
+`bg-space` will no longer be receiving updates, and has been replaced by `brainglobe-space` in all other aspects of the BrainGlobe tool suite.
+
+Old README.md contents are below.
+
 # BG-Space
+
 Anatomical space conventions made easy.
 
 [![Python Version](https://img.shields.io/pypi/pyversions/bg-space.svg)](https://pypi.org/project/bg-space)
@@ -9,8 +17,6 @@ Anatomical space conventions made easy.
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4552537.svg)](https://doi.org/10.5281/zenodo.4552537)
 
-
-
 Working with anatomical images, one often encounters the problem of matching the orientation of stacks with different conventions about axes orientation and order. Moreover, when multiple swaps and flips are involved, it can be annoying to map the same transformations to volumes and points (e.g., coordinates or meshes).
 
 `bg-space` provides a neat way of defining an anatomical space, and of operating stacks and point transformations between spaces.
@@ -20,11 +26,13 @@ If you use `bg-space` for your analyses, please cite its Zenodo DOI https://zeno
 ## Installation
 
 You can install `bg-space` with:
-```
+
+```bash
 pip install bg-space
 ```
 
 ## Usage
+
 To define a new anatomical space, it is sufficient to give the directions of the stack origin position:
 
 ```python
@@ -41,7 +49,6 @@ stack = np.random.rand(3, 2, 4)
 
 mapped_stack = bg.map_stack_to(source_origin, target_origin, stack)
 ```
-
 
 The transformation is handled only with numpy index operations; *i.e.*, no complex
 image affine transformations are applied. This is often useful as the preparatory step for starting any kind of image registration.

--- a/bg_space/__init__.py
+++ b/bg_space/__init__.py
@@ -1,7 +1,7 @@
 from warnings import warn
 
 warn(
-    "bg-space has been retired from the BrainGlobe tool suite and replaced by brainglobe-space. We recommend you uninstall this package and install brainglobe-space instead: https://github.com/brainglobe/brainglobe-space",
+    "bg-space has been renamed to brainglobe-space. To continue receiving updates, we recommend you uninstall this package and install brainglobe-space instead: https://github.com/brainglobe/brainglobe-space",
     DeprecationWarning,
 )
 

--- a/bg_space/__init__.py
+++ b/bg_space/__init__.py
@@ -1,3 +1,10 @@
+from warnings import warn
+
+warn(
+    DeprecationWarning,
+    "bg-space has been retired from the BrainGlobe tool suite and replaced by brainglobe-space. We recommend you uninstall this package and install brainglobe-space instead: https://github.com/brainglobe/brainglobe-space",
+)
+
 __author__ = """Luigi Petrucco @brainglobe"""
 __version__ = "0.6.0"
 

--- a/bg_space/__init__.py
+++ b/bg_space/__init__.py
@@ -1,8 +1,8 @@
 from warnings import warn
 
 warn(
-    DeprecationWarning,
     "bg-space has been retired from the BrainGlobe tool suite and replaced by brainglobe-space. We recommend you uninstall this package and install brainglobe-space instead: https://github.com/brainglobe/brainglobe-space",
+    DeprecationWarning,
 )
 
 __author__ = """Luigi Petrucco @brainglobe"""

--- a/tox.ini
+++ b/tox.ini
@@ -12,4 +12,4 @@ python =
 extras =
     dev
 commands =
-    pytest -v --color=yes --cov=bg_space --cov-report=xml
+    pytest -v --color=yes --cov=bg_space --cov-report=xml -W ignore::DeprecationWarning


### PR DESCRIPTION
Starts the ball rolling on #37 |

# Prepares the "old" `bg-space` name for retirement. 

Ideally don't merge this until the replacement (renaming) PR is open and ready, so we can follow up with an upload of the replacement package.