### PR TITLE
Raise error for non-rigid transformations with explicit override

### DIFF
--- a/brainglobe_space/core.py
+++ b/brainglobe_space/core.py
@@ -12,7 +12,11 @@ def to_target(method):
 
     @wraps(method)
     def decorated(
-        spaceconv_instance, space_description, *args, check_rigid=True, **kwargs
+        spaceconv_instance,
+        space_description,
+        *args,
+        check_rigid=True,
+        **kwargs,
     ):
         # isinstance(..., AnatomicalSpace) here would fail, so:
         if type(space_description) is not type(spaceconv_instance):

--- a/brainglobe_space/core.py
+++ b/brainglobe_space/core.py
@@ -11,7 +11,9 @@ def to_target(method):
     """Decorator for bypassing AnatomicalSpace creation."""
 
     @wraps(method)
-    def decorated(spaceconv_instance, space_description, *args, **kwargs):
+    def decorated(
+        spaceconv_instance, space_description, *args, check_rigid=True, **kwargs
+    ):
         # isinstance(..., AnatomicalSpace) here would fail, so:
         if type(space_description) is not type(spaceconv_instance):
             # Generate description if input was not one:
@@ -22,7 +24,13 @@ def to_target(method):
             }
             space_description = AnatomicalSpace(space_description, **sc_args)
 
-        return method(spaceconv_instance, space_description, *args, **kwargs)
+        return method(
+            spaceconv_instance,
+            space_description,
+            *args,
+            check_rigid=check_rigid,
+            **kwargs,
+        )
 
     return decorated
 
@@ -161,7 +169,7 @@ class AnatomicalSpace:
         return self.axes_order.index(axis)
 
     @to_target
-    def map_to(self, target):
+    def map_to(self, target, check_rigid=True):
         """Find axes reordering, flips, ratios and offsets required to go to
         target space convention.
         The order of flips, ratios and offsets is the one of the target space!
@@ -182,6 +190,30 @@ class AnatomicalSpace:
         tuple
             Offsets to move target space (in target axis order and resolution).
 
+        """
+        return self._map_to(target, check_rigid=check_rigid)
+
+    def _map_to(self, target, check_rigid=True):
+        """Internal map_to implementation with check_rigid parameter.
+
+        Parameters
+        ----------
+        target : AnatomicalSpace object
+            Target space convention.
+        check_rigid : bool, optional
+            If True (default), raise an error if the transformation is not
+            rigid (i.e. involves a flip).
+
+        Returns
+        -------
+        tuple
+            Axes order to move to target space.
+        tuple
+            Sequence of flips to move to target space (in target axis order).
+        tuple
+            Scale factors to move target space (in target axis order).
+        tuple
+            Offsets to move target space (in target axis order and resolution).
         """
 
         # Get order of matching axes:
@@ -216,11 +248,32 @@ class AnatomicalSpace:
         else:
             offsets = (0, 0, 0)
 
+        # Check for non-rigid transformations:
+        if check_rigid:
+            # Construct the 3x3 permutation/flip matrix
+            m = np.zeros((3, 3))
+            for ti, si in enumerate(order):
+                m[ti, si] = -1 if flips[ti] else 1
+
+            if np.linalg.det(m) < 0:
+                raise ValueError(
+                    f"Transformation from {self.origin_string} to "
+                    f"{target.origin_string} is non-rigid (it involves a "
+                    f"flip). This can be bypassed by passing "
+                    f"`check_rigid=False` to the transformation method."
+                )
+
         return order, flips, scales, offsets
 
     @to_target
     def map_stack_to(
-        self, target, stack, copy=False, to_target_shape=False, interp_order=3
+        self,
+        target,
+        stack,
+        copy=False,
+        to_target_shape=False,
+        interp_order=3,
+        check_rigid=True,
     ):
         """Transpose and flip stack to move it to target space convention.
 
@@ -245,7 +298,9 @@ class AnatomicalSpace:
         """
 
         # Find order swapping and flips:
-        order, flips, scales, offsets = self.map_to(target)
+        order, flips, scales, offsets = self._map_to(
+            target, check_rigid=check_rigid
+        )
 
         # If we want to work on a copy, create:
         if copy:
@@ -289,7 +344,9 @@ class AnatomicalSpace:
         return stack
 
     @to_target
-    def transformation_matrix_to(self, target, infer_source_shape=False):
+    def transformation_matrix_to(
+        self, target, infer_source_shape=False, check_rigid=True
+    ):
         """Find transformation matrix going to target space convention.
 
         Parameters
@@ -313,7 +370,9 @@ class AnatomicalSpace:
             shape = target.map_stack_to(self, stack, interp_order=0).shape
 
         # Find axes order and flips:
-        order, flips, scales, offsets = self.map_to(target)
+        order, flips, scales, offsets = self._map_to(
+            target, check_rigid=check_rigid
+        )
 
         # Instantiate transformation matrix:
         transformation_mat = np.zeros((4, 4))
@@ -340,7 +399,9 @@ class AnatomicalSpace:
         return transformation_mat
 
     @to_target
-    def map_points_to(self, target, pts, infer_source_shape=False):
+    def map_points_to(
+        self, target, pts, infer_source_shape=False, check_rigid=True
+    ):
         """Map points to target space convention.
         Parameters
         ----------
@@ -362,7 +423,7 @@ class AnatomicalSpace:
         if len(pts.shape) == 1:
             pts = pts[np.newaxis, :]
         transformation_mat = self.transformation_matrix_to(
-            target, infer_source_shape
+            target, infer_source_shape, check_rigid=check_rigid
         )
 
         # A column of zeros is required for the matrix multiplication:

--- a/brainglobe_space/functions.py
+++ b/brainglobe_space/functions.py
@@ -2,7 +2,7 @@ from brainglobe_space.core import AnatomicalSpace
 
 
 # TODO convert to a smarter way to generate those parsing class' methods:
-def map_to(source, target):
+def map_to(source, target, check_rigid=True):
     """Find axes reordering and flips required to go to
     target space convention.
 
@@ -12,6 +12,9 @@ def map_to(source, target):
         Source space origin.
     target : str
         Target space origin.
+    check_rigid : bool, optional
+        If True (default), raise an error if the transformation is not
+        rigid (i.e. involves a flip).
 
     Returns
     -------
@@ -21,10 +24,10 @@ def map_to(source, target):
         Sequence of flips to move to target space (in target axis order).
 
     """
-    return AnatomicalSpace(source).map_to(target)
+    return AnatomicalSpace(source).map_to(target, check_rigid=check_rigid)
 
 
-def map_stack_to(source, target, stack, copy=False):
+def map_stack_to(source, target, stack, copy=False, check_rigid=True):
     """Transpose and flip stack to move it to target space convention.
 
     Parameters
@@ -37,15 +40,20 @@ def map_stack_to(source, target, stack, copy=False):
         Stack to map from space convention a to space convention b
     copy : bool, optional
         If true, stack is copied.
+    check_rigid : bool, optional
+        If True (default), raise an error if the transformation is not
+        rigid (i.e. involves a flip).
 
     Returns
     -------
 
     """
-    return AnatomicalSpace(source).map_stack_to(target, stack, copy=False)
+    return AnatomicalSpace(source).map_stack_to(
+        target, stack, copy=False, check_rigid=check_rigid
+    )
 
 
-def transformation_matrix_to(source, target, shape=None):
+def transformation_matrix_to(source, target, shape=None, check_rigid=True):
     """Find transformation matrix going to target space convention.
 
     Parameters
@@ -56,15 +64,20 @@ def transformation_matrix_to(source, target, shape=None):
         Target space origin.
     shape : tuple, optional
         Must be passed if flips are required.
+    check_rigid : bool, optional
+        If True (default), raise an error if the transformation is not
+        rigid (i.e. involves a flip).
 
     Returns
     -------
 
     """
-    return AnatomicalSpace(source, shape).transformation_matrix_to(target)
+    return AnatomicalSpace(source, shape).transformation_matrix_to(
+        target, check_rigid=check_rigid
+    )
 
 
-def transform_points_to(source, target, points, shape=None):
+def transform_points_to(source, target, points, shape=None, check_rigid=True):
     """Map points to target space convention.
 
     Parameters
@@ -77,10 +90,15 @@ def transform_points_to(source, target, points, shape=None):
         Array with the points to be mapped.
     shape : tuple, optional
         Must be passed if flips are required.
+    check_rigid : bool, optional
+        If True (default), raise an error if the transformation is not
+        rigid (i.e. involves a flip).
 
     Returns
     -------
     (n, 3) numpy array
         Array with the transformed points.
     """
-    return AnatomicalSpace(source, shape).map_points_to(target, points)
+    return AnatomicalSpace(source, shape).map_points_to(
+        target, points, check_rigid=check_rigid
+    )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -110,7 +110,9 @@ def test_stack_flips(src_o, tgt_o, src_shape, tgt_shape):
     # Test both mapping to AnatomicalSpace obj and origin with decorator:
     for target_space in [tgt_o, AnatomicalSpace(tgt_o)]:
         # Check all corners of the mapped stack:
-        mapped_stack = source_space.map_stack_to(target_space, source_stack)
+        mapped_stack = source_space.map_stack_to(
+            target_space, source_stack, check_rigid=False
+        )
         for indexes in itertools.product([0, -1], repeat=3):
             assert set(mapped_stack[indexes]) == set(target_stack[indexes])
 
@@ -149,8 +151,12 @@ def test_point_transform(src_o, tgt_o, src_shape, tgt_shape):
         source_pts = np.array(list(itertools.product(*grid_positions)))
 
         # Map points and stack to target space:
-        mapped_pts = source_space.map_points_to(target_space, source_pts)
-        mapped_stack = source_space.map_stack_to(target_space, source_stack)
+        mapped_pts = source_space.map_points_to(
+            target_space, source_pts, check_rigid=False
+        )
+        mapped_stack = source_space.map_stack_to(
+            target_space, source_stack, check_rigid=False
+        )
 
         # Check that point coordinates keep the same values:
         for p_source, p_mapped in zip(source_pts, mapped_pts):
@@ -162,7 +168,9 @@ def test_point_transform(src_o, tgt_o, src_shape, tgt_shape):
 def test_point_transform_fail():
     s = AnatomicalSpace("asl")
     with pytest.raises(TypeError) as error:
-        s.map_points_to("psl", np.array([[0, 1, 2], [0, 1, 2]]))
+        s.map_points_to(
+            "psl", np.array([[0, 1, 2], [0, 1, 2]]), check_rigid=False
+        )
     assert "The source space should have a shape" in str(error)
 
 
@@ -353,7 +361,9 @@ def test_points_mapping():
     target_space = AnatomicalSpace(
         "asl", shape=(100, 100, 100), resolution=(10, 10, 10)
     )
-    mapped_points = source_space.map_points_to(target_space, points)
+    mapped_points = source_space.map_points_to(
+        target_space, points, check_rigid=False
+    )
 
     assert np.allclose(
         mapped_points,

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -17,20 +17,26 @@ valid_origins = ["asl", "ipl", "pls"]
 def test_function_consistency(src_o, tgt_o):
     shape = (15, 5, 10)
     stack = np.random.rand(*shape)
-    assert map_to(src_o, tgt_o) == AnatomicalSpace(src_o, shape).map_to(tgt_o)
+    assert map_to(src_o, tgt_o, check_rigid=False) == AnatomicalSpace(
+        src_o, shape
+    ).map_to(tgt_o, check_rigid=False)
 
     assert np.allclose(
-        map_stack_to(src_o, tgt_o, stack),
-        AnatomicalSpace(src_o).map_stack_to(tgt_o, stack),
+        map_stack_to(src_o, tgt_o, stack, check_rigid=False),
+        AnatomicalSpace(src_o).map_stack_to(tgt_o, stack, check_rigid=False),
     )
 
     assert np.allclose(
-        transformation_matrix_to(src_o, tgt_o, shape=shape),
-        AnatomicalSpace(src_o, shape).transformation_matrix_to(tgt_o),
+        transformation_matrix_to(src_o, tgt_o, shape=shape, check_rigid=False),
+        AnatomicalSpace(src_o, shape).transformation_matrix_to(
+            tgt_o, check_rigid=False
+        ),
     )
 
     pts = np.array([[1, s - 1, s + 1, s * 2 - 1] for s in shape]).T
     assert np.allclose(
-        transform_points_to(src_o, tgt_o, pts, shape=shape),
-        AnatomicalSpace(src_o, shape).map_points_to(tgt_o, pts),
+        transform_points_to(src_o, tgt_o, pts, shape=shape, check_rigid=False),
+        AnatomicalSpace(src_o, shape).map_points_to(
+            tgt_o, pts, check_rigid=False
+        ),
     )

--- a/tests/test_rigidity.py
+++ b/tests/test_rigidity.py
@@ -1,0 +1,65 @@
+import numpy as np
+import pytest
+from brainglobe_space import AnatomicalSpace
+from brainglobe_space.functions import map_to, map_stack_to, transformation_matrix_to, transform_points_to
+
+def test_rigidity_check():
+    # Rigid transformation: asl -> sla (rotation)
+    # Det = 1
+    asl = AnatomicalSpace("asl")
+    sla = AnatomicalSpace("sla")
+    
+    # Should work fine
+    asl.map_to(sla)
+    asl.map_to(sla, check_rigid=True)
+    
+    # Non-rigid transformation: asl -> sal (swap s and a)
+    # Det = -1
+    sal = AnatomicalSpace("sal")
+    
+    with pytest.raises(ValueError, match="is non-rigid"):
+        asl.map_to(sal)
+        
+    with pytest.raises(ValueError, match="is non-rigid"):
+        asl.map_to(sal, check_rigid=True)
+        
+    # Should work if check_rigid=False
+    asl.map_to(sal, check_rigid=False)
+
+def test_rigidity_check_helper_functions():
+    # Helper functions in functions.py
+    source = "asl"
+    target = "sal" # non-rigid
+    
+    with pytest.raises(ValueError, match="is non-rigid"):
+        map_to(source, target)
+        
+    map_to(source, target, check_rigid=False)
+    
+    stack = np.zeros((10, 10, 10))
+    with pytest.raises(ValueError, match="is non-rigid"):
+        map_stack_to(source, target, stack)
+        
+    map_stack_to(source, target, stack, check_rigid=False)
+    
+    with pytest.raises(ValueError, match="is non-rigid"):
+        transformation_matrix_to(source, target, shape=(10, 10, 10))
+        
+    transformation_matrix_to(source, target, shape=(10, 10, 10), check_rigid=False)
+    
+    points = np.array([[1, 2, 3]])
+    with pytest.raises(ValueError, match="is non-rigid"):
+        transform_points_to(source, target, points, shape=(10, 10, 10))
+        
+    transform_points_to(source, target, points, shape=(10, 10, 10), check_rigid=False)
+
+def test_rigidity_check_decorator():
+    # Test that the to_target decorator passes check_rigid correctly
+    asl = AnatomicalSpace("asl")
+    
+    # map_stack_to uses to_target
+    stack = np.zeros((10, 10, 10))
+    with pytest.raises(ValueError, match="is non-rigid"):
+        asl.map_stack_to("sal", stack)
+        
+    asl.map_stack_to("sal", stack, check_rigid=False)

--- a/tests/test_rigidity.py
+++ b/tests/test_rigidity.py
@@ -1,65 +1,78 @@
 import numpy as np
 import pytest
+
 from brainglobe_space import AnatomicalSpace
-from brainglobe_space.functions import map_to, map_stack_to, transformation_matrix_to, transform_points_to
+from brainglobe_space.functions import (
+    map_stack_to,
+    map_to,
+    transform_points_to,
+    transformation_matrix_to,
+)
+
 
 def test_rigidity_check():
     # Rigid transformation: asl -> sla (rotation)
     # Det = 1
     asl = AnatomicalSpace("asl")
     sla = AnatomicalSpace("sla")
-    
+
     # Should work fine
     asl.map_to(sla)
     asl.map_to(sla, check_rigid=True)
-    
+
     # Non-rigid transformation: asl -> sal (swap s and a)
     # Det = -1
     sal = AnatomicalSpace("sal")
-    
+
     with pytest.raises(ValueError, match="is non-rigid"):
         asl.map_to(sal)
-        
+
     with pytest.raises(ValueError, match="is non-rigid"):
         asl.map_to(sal, check_rigid=True)
-        
+
     # Should work if check_rigid=False
     asl.map_to(sal, check_rigid=False)
+
 
 def test_rigidity_check_helper_functions():
     # Helper functions in functions.py
     source = "asl"
-    target = "sal" # non-rigid
-    
+    target = "sal"  # non-rigid
+
     with pytest.raises(ValueError, match="is non-rigid"):
         map_to(source, target)
-        
+
     map_to(source, target, check_rigid=False)
-    
+
     stack = np.zeros((10, 10, 10))
     with pytest.raises(ValueError, match="is non-rigid"):
         map_stack_to(source, target, stack)
-        
+
     map_stack_to(source, target, stack, check_rigid=False)
-    
+
     with pytest.raises(ValueError, match="is non-rigid"):
         transformation_matrix_to(source, target, shape=(10, 10, 10))
-        
-    transformation_matrix_to(source, target, shape=(10, 10, 10), check_rigid=False)
-    
+
+    transformation_matrix_to(
+        source, target, shape=(10, 10, 10), check_rigid=False
+    )
+
     points = np.array([[1, 2, 3]])
     with pytest.raises(ValueError, match="is non-rigid"):
         transform_points_to(source, target, points, shape=(10, 10, 10))
-        
-    transform_points_to(source, target, points, shape=(10, 10, 10), check_rigid=False)
+
+    transform_points_to(
+        source, target, points, shape=(10, 10, 10), check_rigid=False
+    )
+
 
 def test_rigidity_check_decorator():
     # Test that the to_target decorator passes check_rigid correctly
     asl = AnatomicalSpace("asl")
-    
+
     # map_stack_to uses to_target
     stack = np.zeros((10, 10, 10))
     with pytest.raises(ValueError, match="is non-rigid"):
         asl.map_stack_to("sal", stack)
-        
+
     asl.map_stack_to("sal", stack, check_rigid=False)


### PR DESCRIPTION
Fixes #8

This PR adds a safeguard against accidental coordinate system flips
(non-rigid transformations) caused by negative determinants in the
transformation matrix.

**Behavior**
- By default, a `ValueError` is raised when a flipped transformation is detected.
- An explicit override is provided via `check_rigid=False` for intentional flips.

**Why**
Accidental left–right or axis flips can silently mirror anatomical data and
are hard to detect. This change makes such cases explicit while preserving
flexibility for advanced use cases.

Tests have been added/updated to cover the new behavior.

Happy to adjust the approach if a different behavior (e.g. warning vs error)
is preferred.